### PR TITLE
Cross platform path separator and command function

### DIFF
--- a/lib/argv.js
+++ b/lib/argv.js
@@ -6,7 +6,7 @@ var PATH = require( 'path' ),
 	rdash = /^\-/,
 	rddash = /^\-\-/,
 	ristarget = /^[^\-]/,
-	SCRIPT_NAME = ( process.argv[ 1 ] || '' ).split( '/' ).pop(),
+	SCRIPT_NAME = ( process.argv[ 1 ] || '' ).split( PATH.sep ).pop(),
 	helpOption = {
 		name: 'help',
 		short: 'h',
@@ -198,7 +198,7 @@ module.exports = self = {
 				}
 
 				// Attach option to submodule
-				mod = self.mods[ mod ];	
+				mod = self.mods[ mod ];
 				mod.options[ object.name ] = object;
 
 				// Attach shorthand
@@ -440,8 +440,31 @@ module.exports = self = {
 			console.log( "\n" + e + ". Trigger '" + self.name + " -h' for more details.\n\n" );
 			process.exit( 1 );
 		}
-	}
+	},
 
+	command: function(command) {
+    if (command !== undefined) {
+      SCRIPT_NAME = command;
+      self.name = command;
+      if (self.options.version !== undefined) {
+        self.options.version.example = command + " --version";
+        self.options.version.name = command;
+      }
+      self.options.help = {
+        name: 'help',
+        short: 'h',
+        type: function() { return true; },
+        description: 'Displays help information about this script',
+        example: "'" + SCRIPT_NAME + " -h' or '" + SCRIPT_NAME + " --help'",
+        onset: function(args) {
+          self.help(args.mod);
+          process.exit(0);
+        }
+      }
+    }
+
+    return self;
+  }
 };
 
 


### PR DESCRIPTION
### Changes
* Changed from split( '/' ) to split( PATH.sep ) in order to support Windows file separators;
* Implemented 'command' function, to set a custom script name for cases when it is installed globally, so the examples will show the cli command, and not the full file path.

I hope it helps someone other than me =)