### PR TITLE
modification run method

### DIFF
--- a/lib/argv.js
+++ b/lib/argv.js
@@ -328,8 +328,8 @@ module.exports = self = {
 	},
 
 	// Runs the arguments parser
-	_run: function( argv ) {
-		var args = { targets: [], options: {} },
+	_run: function( argv , isExc=true) {
+		var args = { targets: [], options: {} ,rest_argv:[],rest_args:{}  },
 			opts = self.options,
 			shortOpts = self.short,
 			skip = false;
@@ -346,7 +346,7 @@ module.exports = self = {
 
 		// Iterate over arguments
 		argv.forEach(function( arg, i ) {
-			var peek = argv[ i + 1 ], option, index, value;
+			var farg=arg, peek = argv[ i + 1 ], option, index, value;
 
 			// Allow skipping of arguments
 			if ( skip ) {
@@ -367,7 +367,12 @@ module.exports = self = {
 
 				// Be strict, if option doesn't exist, throw and error
 				if ( ! ( option = opts[ arg ] ) ) {
-					throw "Option '--" + arg + "' not supported";
+                    if(isExc){
+                        throw "Option '--" + arg + "' not supported";
+                    }
+                    args.rest_argv.push(farg);
+                    args.rest_args[arg]=value;
+                    return;
 				}
 
 				// Send through type converter
@@ -385,7 +390,12 @@ module.exports = self = {
 				if ( arg.length > 1 ) {
 					arg.split( '' ).forEach(function( character ) {
 						if ( ! ( option = shortOpts[ character ] ) ) {
-							throw "Option '-" + character + "' not supported";
+							if(isExc){
+                                throw "Option '-" + character + "' not supported";
+                            }
+                            args.rest_argv.push(farg);
+                            args.rest_args[character]='true';
+                            return;
 						}
 
 						args.options[ option.name ] = option.type( 'true', option.name, args.options, args );
@@ -394,7 +404,12 @@ module.exports = self = {
 				else {
 					// Ensure that an option exists
 					if ( ! ( option = shortOpts[ arg ] ) ) {
-						throw "Option '-" + arg + "' not supported";
+                        if(isExc) {
+                            throw "Option '-" + arg + "' not supported";
+                        }
+                        args.rest_argv.push(farg);
+                        args.rest_args[arg]=peek??'true';
+                        return;
 					}
 
 					// Check next option for target association
@@ -428,9 +443,9 @@ module.exports = self = {
 		return args;
 	},
 
-	run: function( argv ) {
+	run: function( argv , isExc=true) {
 		try {
-			return self._run( argv );
+			return self._run( argv , isExc );
 		}
 		catch ( e ) {
 			if ( ! self.isString( e ) ) {


### PR DESCRIPTION
Exemples
```js
let mod=require('./lib/argv.js');
let argv=JSON.parse(process.env.npm_config_argv);
console.log(
	mod
	.option({
	    name:'qwer',
	    short:'q',
	    type:'string'
	})
	.run(argv.remain,false) // don't throw an error
	/* result
		{
			targets:[],
			options:{},
			rest_argv:[], rest arguments that are not declared by option
			rest_args:{}, rest arguments that are not declared by option (parsed arguments)
		}
	*/
);  
```