### PR TITLE
url → homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "argv",
 	"description": "CLI Argument Parser",
-	"url": "http://codenothing.github.com/argv/",
+	"homepage": "http://codenothing.github.com/argv/",
 	"keywords": [ "cli", "argv", "options" ],
 	"author": "Corey Hart <corey@codenothing.com>",
 	"version": "0.0.3pre",


### PR DESCRIPTION
makes it link back to this repo from npm. I don't think url ever was a package.json property. 